### PR TITLE
Temp dir default

### DIFF
--- a/orio/matrix.py
+++ b/orio/matrix.py
@@ -53,8 +53,7 @@ class BedMatrix(object):
             if os.path.dirname(self.output_matrix) != "":
                 assert os.path.exists(os.path.dirname(self.opposite_strand_fn))
             if not self.stranded_bed:
-                raise ValueError("Cannot report opposite strand coverage \
-                                 without stranded_bed flag!!")
+                raise ValueError("Cannot report opposite strand coverage without stranded_bed flag!!")  # noqa
         if self.stranded_bigwigs:
             assert os.path.exists(self.plus_bigwig)
             assert os.path.exists(self.minus_bigwig)
@@ -206,8 +205,7 @@ class BedMatrix(object):
                         if bed_fields >= 6:  # Contains strand information?
                             strand = line.strip().split()[5]
                             if strand in self.DUMMY_VALUES:
-                                raise ValueError('Strand column is not \
-                                    informative!!')
+                                raise ValueError('Strand column is not informative!!')  # noqa
                         else:
                             raise ValueError("BED file lacks strand column!!")
                     else:

--- a/orio/matrix.py
+++ b/orio/matrix.py
@@ -19,7 +19,7 @@ class BedMatrix(object):
 
     def __init__(self, bigwigs, feature_bed, output_matrix, anchor, bin_start,
                  bin_number, bin_size, opposite_strand_fn, stranded_bigwigs,
-                 stranded_bed, chrom_sizes, temp_dir):
+                 stranded_bed, chrom_sizes, temp_dir=None):
 
         # Set instance variables
         self.feature_bed = feature_bed
@@ -66,8 +66,9 @@ class BedMatrix(object):
         if os.path.dirname(self.output_matrix) != "":
             assert os.path.exists(os.path.dirname(self.output_matrix))
 
-        if self.temp_dir:
-            os.makedirs(self.temp_dir, exist_ok=True)
+        if self.temp_dir is None:
+            self.temp_dir = tempfile.gettempdir()
+        os.makedirs(self.temp_dir, exist_ok=True)
 
         self.execute()
 
@@ -87,17 +88,11 @@ class BedMatrix(object):
             pass
 
     def create_temps(self):
-        if self.temp_dir:
-            self._plus_filename = tempfile.mkstemp(dir=self.temp_dir)[1]
-            self._minus_filename = tempfile.mkstemp(dir=self.temp_dir)[1]
-            self._unstranded_filename = tempfile.mkstemp(dir=self.temp_dir)[1]
-            self._bedfile = \
-                tempfile.NamedTemporaryFile(mode='w', dir=self.temp_dir)
-        else:
-            self._plus_filename = tempfile.mkstemp()[1]
-            self._minus_filename = tempfile.mkstemp()[1]
-            self._unstranded_filename = tempfile.mkstemp()[1]
-            self._bedfile = tempfile.NamedTemporaryFile(mode='w')
+        path = self.temp_dir
+        self._plus_filename = tempfile.mkstemp(dir=path)[1]
+        self._minus_filename = tempfile.mkstemp(dir=path)[1]
+        self._unstranded_filename = tempfile.mkstemp(dir=path)[1]
+        self._bedfile = tempfile.NamedTemporaryFile(mode='w', dir=path)
 
     def cleanup(self):
         self.tryDelete(self._plus_filename)


### PR DESCRIPTION
Make temp dir an optional input in the `__init__`; use a default temp-path if one is unspecified.
