### PR TITLE
sync requirement versions between orio and orio-web

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # computational
-scipy==0.17.0
-numpy==1.11.0
-pandas==0.18.0
+scipy==0.17.1
+numpy==1.11.1
+pandas==0.18.1
 
 # testing
 pytest==2.9.1


### PR DESCRIPTION
orio has slightly older versions in the requirements file than orio-web. This PR keeps them synced.